### PR TITLE
Fixes issue where the cookie is not present upon redirect in Next.js server-side rendering demo

### DIFF
--- a/nextjs/server-side-rendering/app/oauth/route.ts
+++ b/nextjs/server-side-rendering/app/oauth/route.ts
@@ -27,5 +27,7 @@ export async function GET(request: NextRequest) {
     secure: true,
   });
 
-  return NextResponse.redirect(`${request.nextUrl.origin}/account`);
+  const response = NextResponse.redirect(`${request.nextUrl.origin}/account`);
+  response.cookies.set(SESSION_COOKIE, session.secret);
+  return response;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

There is currently an issue with Next.js where setting a cookie using `cookies()` and then returning `NextResponse` will not add the cookie to that response meaning that the session is not set and requires a refresh. This adds the cookie to the response along side setting it using `cookies()` to make sure that upon redirecting, the session is present.

## Test Plan

I manually tested this, both as a fresh install, on existing projects and had [confirmation from others](https://discord.com/channels/564160730845151244/1255880866031341588) that this approach worked when they were using this as repo as a starting point.

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes